### PR TITLE
Added scientific libraries to requirements.txt for non-conda users

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,11 @@ pytest-randomly
 
 sphinxbootstrap4theme
 
+numpy>=1.11.3
+pandas>=1.2.3
+scikit-learn>=0.22
+scipy>=1.5.0
+hoggorm>=0.13.3
+hoggormplot>=0.13.2
+matplotlib>=3.2.2
+seaborn>=0.10


### PR DESCRIPTION
Added all the required libraries(that are found in conda) to requirements.txt. 
This is useful in case there are any pip only users.